### PR TITLE
Darkens flash effect by default

### DIFF
--- a/code/modules/client/preferences/darkened_flash.dm
+++ b/code/modules/client/preferences/darkened_flash.dm
@@ -1,6 +1,6 @@
 /// When toggled, being flashed will show a dark screen rather than a light one.
 /datum/preference/toggle/darkened_flash
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	default_value = FALSE
+	default_value = true
 	savefile_key = "darkened_flash"
 	savefile_identifier = PREFERENCE_PLAYER

--- a/code/modules/client/preferences/darkened_flash.dm
+++ b/code/modules/client/preferences/darkened_flash.dm
@@ -1,6 +1,6 @@
 /// When toggled, being flashed will show a dark screen rather than a light one.
 /datum/preference/toggle/darkened_flash
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	default_value = true
+	default_value = TRUE
 	savefile_key = "darkened_flash"
 	savefile_identifier = PREFERENCE_PLAYER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes flashes provide a darkened flash by default, rather than a bright white flash. You can still change this in your game preferences under "darkened flash".

## Why It's Good For The Game

Rapid white flashes are both epilepsy hazards and eyestrain inducing.

## Changelog

:cl:
fix: Screen flashes are now dark by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
